### PR TITLE
Added support for overriding the automatic type description.

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -141,6 +141,38 @@ func HandleSomeTest(request *SomeTestRequest) (*SomeTestResponse, error) {
 }
 ```
 
+### Overriding Type Descriptions
+
+To override the automatic type description, an override comment can be attached to the type declaration.
+An override type comment must include the keyword `__TYPE_DESCRIPTION_OVERRIDE__`.
+
+The remainder of the comment, after the keyword, is used to override the type description.
+The override type description must include `<override-type-id> = <override-type-description in JSON>`.
+See `core.FullTypeDescription` for the full list of fields that can be set in the override.
+
+Currently, you cannot override the type description of a field in a struct by attaching the override comment to the field.
+Because of this limitation, fields that are ignored by JSON, using the `-`, cannot be overriden.
+
+For Example:
+
+```
+type SomeTestType struct {
+    // Note: Type overrides are not allowed on a field.
+    TestType
+
+    // Note: Even with a type override, this field will be ignored.
+    TestHiddenType bool `json:"-"`
+}
+
+// Note: Everything before the override keyword is ignored.
+//	__TYPE_DESCRIPTION_OVERRIDE__ "test-type-id" = {
+//	    "category": "Custom Category",
+//	    "description": "Custom Description",
+//      ...
+//	}
+type TestType string
+```
+
 ### Passwords/Tokens
 
 No password or token should be sent to the server as cleartext.

--- a/internal/api/core/describe.go
+++ b/internal/api/core/describe.go
@@ -332,7 +332,7 @@ func DescribeType(customType reflect.Type, addType bool, info TypeInfoCache) (Fu
 		return FullTypeDescription{}, "", TypeInfoCache{}, err
 	}
 
-	overrideTypeID, overrideTypeDescription, err := getTypeOverride(description)
+	overrideTypeDescription, overrideTypeID, err := getTypeOverride(description)
 	if err != nil {
 		return FullTypeDescription{}, "", TypeInfoCache{}, err
 	}
@@ -538,14 +538,14 @@ func getTypeDescription(customType reflect.Type, knownPackages map[string]Struct
 	return description, nil
 }
 
-func getTypeOverride(rawDescription string) (string, *FullTypeDescription, error) {
+func getTypeOverride(rawDescription string) (*FullTypeDescription, string, error) {
 	if !strings.Contains(rawDescription, TYPE_OVERRIDE_INDICATOR) {
-		return "", nil, nil
+		return nil, "", nil
 	}
 
 	commentParts := strings.Split(rawDescription, fmt.Sprintf("%s:", TYPE_OVERRIDE_INDICATOR))
 	if len(commentParts) != 2 {
-		return "", nil, fmt.Errorf("Type override description requires a part after the indicator: '%s'.", rawDescription)
+		return nil, "", fmt.Errorf("Type override description requires a part after the indicator: '%s'.", rawDescription)
 	}
 
 	// Everything after the indicator is a part of the type override.
@@ -553,7 +553,7 @@ func getTypeOverride(rawDescription string) (string, *FullTypeDescription, error
 
 	descriptionParts := strings.Split(commentOverride, "=")
 	if len(descriptionParts) != 2 {
-		return "", nil, fmt.Errorf("Unexpected description override. Expected: '<typeID>=<typeDescription>', Actual: '%s'.", descriptionParts)
+		return nil, "", fmt.Errorf("Unexpected description override. Expected: '<typeID>=<typeDescription>', Actual: '%s'.", descriptionParts)
 	}
 
 	rawTypeID := descriptionParts[0]
@@ -564,10 +564,10 @@ func getTypeOverride(rawDescription string) (string, *FullTypeDescription, error
 	typeDescription := FullTypeDescription{}
 	err := util.JSONFromString(rawTypeDescription, &typeDescription)
 	if err != nil {
-		return "", nil, fmt.Errorf("Failed to convert type override: '%w'.", err)
+		return nil, "", fmt.Errorf("Failed to convert type override: '%w'.", err)
 	}
 
-	return typeID, &typeDescription, nil
+	return &typeDescription, typeID, nil
 }
 
 func isFieldRequired(field reflect.StructField) (bool, error) {

--- a/internal/api/core/describe.go
+++ b/internal/api/core/describe.go
@@ -543,7 +543,7 @@ func getTypeOverride(rawDescription string) (*FullTypeDescription, string, error
 		return nil, "", nil
 	}
 
-	commentParts := strings.Split(rawDescription, fmt.Sprintf("%s:", TYPE_OVERRIDE_INDICATOR))
+	commentParts := strings.Split(rawDescription, TYPE_OVERRIDE_INDICATOR)
 	if len(commentParts) != 2 {
 		return nil, "", fmt.Errorf("Type override description requires a part after the indicator: '%s'.", rawDescription)
 	}

--- a/internal/api/core/describe.go
+++ b/internal/api/core/describe.go
@@ -327,25 +327,24 @@ func DescribeType(customType reflect.Type, addType bool, info TypeInfoCache) (Fu
 		return typeDescription, originalTypeID, info, nil
 	}
 
-	// TODO: Will probably need to remove addType restriction to get a potention type override.
-	if addType {
-		description, err := getTypeDescription(customType, info.KnownPackages)
-		if err != nil {
-			return FullTypeDescription{}, "", TypeInfoCache{}, err
-		}
-
-		overrideTypeID, overrideTypeDescription, err := getTypeOverride(description)
-		if err != nil {
-			return FullTypeDescription{}, "", TypeInfoCache{}, err
-		}
-
-		if overrideTypeDescription != nil {
-			info.TypeMap[overrideTypeID] = *overrideTypeDescription
-			return *overrideTypeDescription, overrideTypeID, info, nil
-		}
-
-		typeDescription.Description = description
+	description, err := getTypeDescription(customType, info.KnownPackages)
+	if err != nil {
+		return FullTypeDescription{}, "", TypeInfoCache{}, err
 	}
+
+	overrideTypeID, overrideTypeDescription, err := getTypeOverride(description)
+	if err != nil {
+		return FullTypeDescription{}, "", TypeInfoCache{}, err
+	}
+
+	if overrideTypeDescription != nil {
+		// Always add an overriden type to the type map.
+		// It may have a custom key and need to be recomputed.
+		info.TypeMap[overrideTypeID] = *overrideTypeDescription
+		return *overrideTypeDescription, overrideTypeID, info, nil
+	}
+
+	typeDescription.Description = description
 
 	switch customType.Kind() {
 	case reflect.Array, reflect.Slice:

--- a/internal/api/core/describe_test.go
+++ b/internal/api/core/describe_test.go
@@ -45,9 +45,12 @@ type secureJSONStruct struct {
 	Pay       int    `json:"-"`
 }
 
+// TODO: Fix test cases that use the embeddedJSONStruct.
+// TODO: It's not returning the overriden type info, look into removing addType restriction.
 type embeddedJSONStruct struct {
 	simpleJSONStruct
 	secureJSONStruct
+	MinServerRoleAdmin
 }
 
 type complexJSONStruct struct {
@@ -157,6 +160,7 @@ func TestDescribeTypeBase(test *testing.T) {
 					AliasType:   "string",
 				},
 			},
+			// TODO: Updated this test case.
 			map[string]FullTypeDescription{
 				mustGetTypeID(reflect.TypeOf((*stringWrapper)(nil)).Elem(), nil): FullTypeDescription{
 					BaseTypeDescription: BaseTypeDescription{

--- a/internal/api/core/describe_test.go
+++ b/internal/api/core/describe_test.go
@@ -65,6 +65,21 @@ type complexPointerStruct struct {
 	Personnel *embeddedJSONStruct `json:"personnel"`
 }
 
+type fullTypeOverrideStruct struct {
+	// TODO
+	// Note: The overriden field name persists.
+	MinServerRoleAdmin
+}
+
+type typeOverrideStruct struct {
+	// Note: Only the overriden type name appears.
+	MinServerRoleAdmin `json:"type-override-struct"`
+}
+
+type ignoredTypeOverride struct {
+	MinServerRoleAdmin `json:"-"`
+}
+
 type errorTypeFalse struct {
 	badTag string `json:"bad-tag" required:"false"`
 }
@@ -743,6 +758,110 @@ func TestDescribeTypeBase(test *testing.T) {
 						Category:    "role",
 						Description: "The requesting user must have a minimum server role of admin to complete this operation.",
 					},
+				},
+			},
+			"",
+		},
+		{
+			reflect.TypeOf((*typeOverrideStruct)(nil)).Elem(),
+			FullTypeDescription{
+				BaseTypeDescription: BaseTypeDescription{
+					Category: "struct",
+				},
+				Fields: []FieldDescription{
+					FieldDescription{
+						BaseFieldDescription: BaseFieldDescription{
+							Name:        "type-override-struct",
+							Type:        "min-server-role-admin",
+							Description: "Note: Only the overriden type name appears.",
+						},
+						Required: false,
+					},
+				},
+			},
+			map[string]FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*typeOverrideStruct)(nil)).Elem(), nil): FullTypeDescription{
+					BaseTypeDescription: BaseTypeDescription{
+						Category: "struct",
+					},
+					Fields: []FieldDescription{
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{
+								Name:        "type-override-struct",
+								Type:        "min-server-role-admin",
+								Description: "Note: Only the overriden type name appears.",
+							},
+							Required: false,
+						},
+					},
+				},
+				"min-server-role-admin": FullTypeDescription{
+					BaseTypeDescription: BaseTypeDescription{
+						Category:    "role",
+						Description: "The requesting user must have a minimum server role of admin to complete this operation.",
+					},
+				},
+			},
+			"",
+		},
+		{
+			reflect.TypeOf((*fullTypeOverrideStruct)(nil)).Elem(),
+			FullTypeDescription{
+				BaseTypeDescription: BaseTypeDescription{
+					Category: "struct",
+				},
+				Fields: []FieldDescription{
+					FieldDescription{
+						BaseFieldDescription: BaseFieldDescription{
+							Name:        "type-override-struct",
+							Type:        "min-server-role-admin",
+							Description: "Note: Only the overriden type name appears.",
+						},
+						Required: false,
+					},
+				},
+			},
+			map[string]FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*typeOverrideStruct)(nil)).Elem(), nil): FullTypeDescription{
+					BaseTypeDescription: BaseTypeDescription{
+						Category: "struct",
+					},
+					Fields: []FieldDescription{
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{
+								Name:        "type-override-struct",
+								Type:        "min-server-role-admin",
+								Description: "Note: Only the overriden type name appears.",
+							},
+							Required: false,
+						},
+					},
+				},
+				"min-server-role-admin": FullTypeDescription{
+					BaseTypeDescription: BaseTypeDescription{
+						Category:    "role",
+						Description: "The requesting user must have a minimum server role of admin to complete this operation.",
+					},
+				},
+			},
+			"",
+		},
+
+		// Ignored type overrides.
+		{
+			reflect.TypeOf((*ignoredTypeOverride)(nil)).Elem(),
+			FullTypeDescription{
+				BaseTypeDescription: BaseTypeDescription{
+					Category: "struct",
+				},
+				Fields: []FieldDescription{},
+			},
+			map[string]FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*ignoredTypeOverride)(nil)).Elem(), nil): FullTypeDescription{
+					BaseTypeDescription: BaseTypeDescription{
+						Category: "struct",
+					},
+					Fields: []FieldDescription{},
 				},
 			},
 			"",

--- a/internal/api/core/describe_test.go
+++ b/internal/api/core/describe_test.go
@@ -65,15 +65,6 @@ type complexPointerStruct struct {
 	Personnel *embeddedJSONStruct `json:"personnel"`
 }
 
-type overrideTypeStruct struct {
-	//	__TYPE_DESCRIPTION_OVERRIDE__: "overriden-type-id" = {
-	//	    "category": "clowns",
-	//	    "description": "This field is ignored in JSON, but it we provided a custom description."
-	//	}
-	SpecialCase string `json:"-"`
-	NormalCase  int    `json:"normal-case"`
-}
-
 type errorTypeFalse struct {
 	badTag string `json:"bad-tag" required:"false"`
 }
@@ -751,39 +742,6 @@ func TestDescribeTypeBase(test *testing.T) {
 					BaseTypeDescription: BaseTypeDescription{
 						Category:    "role",
 						Description: "The requesting user must have a minimum server role of admin to complete this operation.",
-					},
-				},
-			},
-			"",
-		},
-		{
-			reflect.TypeOf((*overrideTypeStruct)(nil)).Elem(),
-			FullTypeDescription{
-				BaseTypeDescription: BaseTypeDescription{
-					Category: "struct",
-				},
-				Fields: []FieldDescription{
-					FieldDescription{
-						BaseFieldDescription: BaseFieldDescription{
-							Name: "normal-case",
-							Type: "int",
-						},
-					},
-				},
-			},
-			map[string]FullTypeDescription{
-				"overriden-type-id": FullTypeDescription{
-					BaseTypeDescription: BaseTypeDescription{
-						Category:    "clowns",
-						Description: "This field is ignored in JSON, but it we provided a custom description.",
-					},
-					Fields: []FieldDescription{
-						FieldDescription{
-							BaseFieldDescription: BaseFieldDescription{
-								Name: "normal-case",
-								Type: "int",
-							},
-						},
 					},
 				},
 			},

--- a/internal/api/core/describe_test.go
+++ b/internal/api/core/describe_test.go
@@ -65,15 +65,14 @@ type complexPointerStruct struct {
 	Personnel *embeddedJSONStruct `json:"personnel"`
 }
 
-type fullTypeOverrideStruct struct {
-	// TODO
-	// Note: The overriden field name persists.
-	MinServerRoleAdmin
-}
-
 type typeOverrideStruct struct {
 	// Note: Only the overriden type name appears.
 	MinServerRoleAdmin `json:"type-override-struct"`
+}
+
+type fullTypeOverrideStruct struct {
+	// Note: The embedded struct name still appears as the field name.
+	MinServerRoleAdmin
 }
 
 type ignoredTypeOverride struct {
@@ -87,6 +86,21 @@ type errorTypeFalse struct {
 type errorTypeTrue struct {
 	badTag string `json:"bad-tag" required:"true"`
 }
+
+//	__TYPE_DESCRIPTION_OVERRIDE__ {
+//	    "category": "override",
+//	    "description": "This type is missing an override type ID."
+//	}
+type errorTypeOverrideID bool
+
+// __TYPE_DESCRIPTION_OVERRIDE__ "error-type-override-type"
+type errorTypeOverrideType bool
+
+//	__TYPE_DESCRIPTION_OVERRIDE__ "error-type-override-JSON" = {
+//	    "category": "override",
+//	    "description": "This type has an invalid JSON structure.",
+//	}
+type errorTypeOverrideJSON bool
 
 func mustGetTypeID(customType reflect.Type, typeConversions map[string]string) string {
 	typeID, err := getTypeID(customType, typeConversions)
@@ -813,25 +827,25 @@ func TestDescribeTypeBase(test *testing.T) {
 				Fields: []FieldDescription{
 					FieldDescription{
 						BaseFieldDescription: BaseFieldDescription{
-							Name:        "type-override-struct",
+							Name:        "MinServerRoleAdmin",
 							Type:        "min-server-role-admin",
-							Description: "Note: Only the overriden type name appears.",
+							Description: "Note: The embedded struct name still appears as the field name.",
 						},
 						Required: false,
 					},
 				},
 			},
 			map[string]FullTypeDescription{
-				mustGetTypeID(reflect.TypeOf((*typeOverrideStruct)(nil)).Elem(), nil): FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*fullTypeOverrideStruct)(nil)).Elem(), nil): FullTypeDescription{
 					BaseTypeDescription: BaseTypeDescription{
 						Category: "struct",
 					},
 					Fields: []FieldDescription{
 						FieldDescription{
 							BaseFieldDescription: BaseFieldDescription{
-								Name:        "type-override-struct",
+								Name:        "MinServerRoleAdmin",
 								Type:        "min-server-role-admin",
-								Description: "Note: Only the overriden type name appears.",
+								Description: "Note: The embedded struct name still appears as the field name.",
 							},
 							Required: false,
 						},
@@ -879,6 +893,24 @@ func TestDescribeTypeBase(test *testing.T) {
 			FullTypeDescription{},
 			nil,
 			"Unexpected required tag value. Expected: '', Actual: 'true'.",
+		},
+		{
+			reflect.TypeOf((*errorTypeOverrideID)(nil)).Elem(),
+			FullTypeDescription{},
+			nil,
+			"Unexpected description override. Expected: '<typeID>=<typeDescription>', Actual:",
+		},
+		{
+			reflect.TypeOf((*errorTypeOverrideType)(nil)).Elem(),
+			FullTypeDescription{},
+			nil,
+			"Unexpected description override. Expected: '<typeID>=<typeDescription>', Actual:",
+		},
+		{
+			reflect.TypeOf((*errorTypeOverrideJSON)(nil)).Elem(),
+			FullTypeDescription{},
+			nil,
+			"Failed to convert type override: 'Could not unmarshal JSON bytes/string",
 		},
 	}
 

--- a/internal/api/core/request_fields.go
+++ b/internal/api/core/request_fields.go
@@ -22,11 +22,6 @@ type CourseUsers map[string]*model.CourseUser
 
 // A request having a field of this type indicates that files from the POST request
 // will be qutomatically read and written to a temp directory on disk.
-
-//	__TYPE_DESCRIPTION_OVERRIDE__: "post-files" = {
-//	    "category": "files",
-//	    "description": "The request must contain files in the POST request."
-//	}
 type POSTFiles struct {
 	TempDir   string   `json:"-"`
 	Filenames []string `json:"-"`

--- a/internal/api/core/request_fields.go
+++ b/internal/api/core/request_fields.go
@@ -22,6 +22,11 @@ type CourseUsers map[string]*model.CourseUser
 
 // A request having a field of this type indicates that files from the POST request
 // will be qutomatically read and written to a temp directory on disk.
+
+//	__TYPE_DESCRIPTION_OVERRIDE__: "post-files" = {
+//	    "category": "files",
+//	    "description": "The request must contain files in the POST request."
+//	}
 type POSTFiles struct {
 	TempDir   string   `json:"-"`
 	Filenames []string `json:"-"`

--- a/internal/api/core/request_role.go
+++ b/internal/api/core/request_role.go
@@ -12,31 +12,31 @@ var minRoleRegex = regexp.MustCompile(`^Min(Server|Course)Role\w+$`)
 // The minimum server roles required encoded as a type so it can be embedded into a request struct.
 // Using any of these implies your request is at least an APIRequestUserContext.
 
-//	__TYPE_DESCRIPTION_OVERRIDE__: "min-server-role-root" = {
+//	__TYPE_DESCRIPTION_OVERRIDE__ "min-server-role-root" = {
 //	    "category": "role",
 //	    "description": "The requesting user must have a minimum server role of root to complete this operation."
 //	}
 type MinServerRoleRoot bool
 
-//	__TYPE_DESCRIPTION_OVERRIDE__: "min-server-role-owner" = {
+//	__TYPE_DESCRIPTION_OVERRIDE__ "min-server-role-owner" = {
 //	    "category": "role",
 //	    "description": "The requesting user must have a minimum server role of owner to complete this operation."
 //	}
 type MinServerRoleOwner bool
 
-//	__TYPE_DESCRIPTION_OVERRIDE__: "min-server-role-admin" = {
+//	__TYPE_DESCRIPTION_OVERRIDE__ "min-server-role-admin" = {
 //	    "category": "role",
 //	    "description": "The requesting user must have a minimum server role of admin to complete this operation."
 //	}
 type MinServerRoleAdmin bool
 
-//	__TYPE_DESCRIPTION_OVERRIDE__: "min-server-role-course-creator" = {
+//	__TYPE_DESCRIPTION_OVERRIDE__ "min-server-role-course-creator" = {
 //	    "category": "role",
 //	    "description": "The requesting user must have a minimum server role of course creator to complete this operation."
 //	}
 type MinServerRoleCourseCreator bool
 
-//	__TYPE_DESCRIPTION_OVERRIDE__: "min-server-role-user" = {
+//	__TYPE_DESCRIPTION_OVERRIDE__ "min-server-role-user" = {
 //	    "category": "role",
 //	    "description": "The requesting user must have a minimum server role of user to complete this operation."
 //	}
@@ -45,31 +45,31 @@ type MinServerRoleUser bool
 // The minimum course roles required encoded as a type so it can be embedded into a request struct.
 // Using any of these implies your request is at least an APIRequestCourseUserContext.
 
-//	__TYPE_DESCRIPTION_OVERRIDE__: "min-course-role-owner" = {
+//	__TYPE_DESCRIPTION_OVERRIDE__ "min-course-role-owner" = {
 //	    "category": "role",
 //	    "description": "The requesting user must have a minimum course role of owner to complete this operation."
 //	}
 type MinCourseRoleOwner bool
 
-//	__TYPE_DESCRIPTION_OVERRIDE__: "min-course-role-admin" = {
+//	__TYPE_DESCRIPTION_OVERRIDE__ "min-course-role-admin" = {
 //	    "category": "role",
 //	    "description": "The requesting user must have a minimum course role of admin to complete this operation."
 //	}
 type MinCourseRoleAdmin bool
 
-//	__TYPE_DESCRIPTION_OVERRIDE__: "min-course-role-grader" = {
+//	__TYPE_DESCRIPTION_OVERRIDE__ "min-course-role-grader" = {
 //	    "category": "role",
 //	    "description": "The requesting user must have a minimum course role of grader to complete this operation."
 //	}
 type MinCourseRoleGrader bool
 
-//	__TYPE_DESCRIPTION_OVERRIDE__: "min-course-role-student" = {
+//	__TYPE_DESCRIPTION_OVERRIDE__ "min-course-role-student" = {
 //	    "category": "role",
 //	    "description": "The requesting user must have a minimum course role of student to complete this operation."
 //	}
 type MinCourseRoleStudent bool
 
-//	__TYPE_DESCRIPTION_OVERRIDE__: "min-course-role-other" = {
+//	__TYPE_DESCRIPTION_OVERRIDE__ "min-course-role-other" = {
 //	    "category": "role",
 //	    "description": "The requesting user must have a minimum course role of other to complete this operation."
 //	}

--- a/internal/api/core/request_role.go
+++ b/internal/api/core/request_role.go
@@ -13,6 +13,11 @@ var minRoleRegex = regexp.MustCompile(`^Min(Server|Course)Role\w+$`)
 // Using any of these implies your request is at least an APIRequestUserContext.
 type MinServerRoleRoot bool
 type MinServerRoleOwner bool
+
+//	__TYPE_DESCRIPTION_OVERRIDE__: "min-role-server-admin" = {
+//	    "category": "role",
+//	    "description": "Test server admin!"
+//	}
 type MinServerRoleAdmin bool
 type MinServerRoleCourseCreator bool
 type MinServerRoleUser bool

--- a/internal/api/core/request_role.go
+++ b/internal/api/core/request_role.go
@@ -11,23 +11,68 @@ var minRoleRegex = regexp.MustCompile(`^Min(Server|Course)Role\w+$`)
 
 // The minimum server roles required encoded as a type so it can be embedded into a request struct.
 // Using any of these implies your request is at least an APIRequestUserContext.
+
+//	__TYPE_DESCRIPTION_OVERRIDE__: "min-server-role-root" = {
+//	    "category": "role",
+//	    "description": "The requesting user must have a minimum server role of root to complete this operation."
+//	}
 type MinServerRoleRoot bool
+
+//	__TYPE_DESCRIPTION_OVERRIDE__: "min-server-role-owner" = {
+//	    "category": "role",
+//	    "description": "The requesting user must have a minimum server role of owner to complete this operation."
+//	}
 type MinServerRoleOwner bool
 
-//	__TYPE_DESCRIPTION_OVERRIDE__: "min-role-server-admin" = {
+//	__TYPE_DESCRIPTION_OVERRIDE__: "min-server-role-admin" = {
 //	    "category": "role",
-//	    "description": "Test server admin!"
+//	    "description": "The requesting user must have a minimum server role of admin to complete this operation."
 //	}
 type MinServerRoleAdmin bool
+
+//	__TYPE_DESCRIPTION_OVERRIDE__: "min-server-role-course-creator" = {
+//	    "category": "role",
+//	    "description": "The requesting user must have a minimum server role of course creator to complete this operation."
+//	}
 type MinServerRoleCourseCreator bool
+
+//	__TYPE_DESCRIPTION_OVERRIDE__: "min-server-role-user" = {
+//	    "category": "role",
+//	    "description": "The requesting user must have a minimum server role of user to complete this operation."
+//	}
 type MinServerRoleUser bool
 
 // The minimum course roles required encoded as a type so it can be embedded into a request struct.
 // Using any of these implies your request is at least an APIRequestCourseUserContext.
+
+//	__TYPE_DESCRIPTION_OVERRIDE__: "min-course-role-owner" = {
+//	    "category": "role",
+//	    "description": "The requesting user must have a minimum course role of owner to complete this operation."
+//	}
 type MinCourseRoleOwner bool
+
+//	__TYPE_DESCRIPTION_OVERRIDE__: "min-course-role-admin" = {
+//	    "category": "role",
+//	    "description": "The requesting user must have a minimum course role of admin to complete this operation."
+//	}
 type MinCourseRoleAdmin bool
+
+//	__TYPE_DESCRIPTION_OVERRIDE__: "min-course-role-grader" = {
+//	    "category": "role",
+//	    "description": "The requesting user must have a minimum course role of grader to complete this operation."
+//	}
 type MinCourseRoleGrader bool
+
+//	__TYPE_DESCRIPTION_OVERRIDE__: "min-course-role-student" = {
+//	    "category": "role",
+//	    "description": "The requesting user must have a minimum course role of student to complete this operation."
+//	}
 type MinCourseRoleStudent bool
+
+//	__TYPE_DESCRIPTION_OVERRIDE__: "min-course-role-other" = {
+//	    "category": "role",
+//	    "description": "The requesting user must have a minimum course role of other to complete this operation."
+//	}
 type MinCourseRoleOther bool
 
 // Take a request (or any object),

--- a/resources/api.json
+++ b/resources/api.json
@@ -4,6 +4,10 @@
             "description": "Send an email to course users.",
             "input": [
                 {
+                    "name": "MinCourseRoleGrader",
+                    "type": "min-course-role-grader"
+                },
+                {
                     "name": "bcc",
                     "type": "[]model.CourseUserReference"
                 },
@@ -70,6 +74,10 @@
             "description": "Update an existing course.",
             "input": [
                 {
+                    "name": "MinCourseRoleAdmin",
+                    "type": "min-course-role-admin"
+                },
+                {
                     "name": "course-id",
                     "type": "string",
                     "description": "The ID of the course to make this request to.",
@@ -98,6 +106,10 @@
         "courses/assignments/get": {
             "description": "Get the information for a course assignment.",
             "input": [
+                {
+                    "name": "MinCourseRoleOther",
+                    "type": "min-course-role-other"
+                },
                 {
                     "name": "assignment-id",
                     "type": "string",
@@ -134,6 +146,10 @@
             "description": "List the assignments in the course.",
             "input": [
                 {
+                    "name": "MinCourseRoleOther",
+                    "type": "min-course-role-other"
+                },
+                {
                     "name": "course-id",
                     "type": "string",
                     "description": "The ID of the course to make this request to.",
@@ -163,6 +179,10 @@
             "description": "Fetch an assignment grading report for a course.",
             "input": [
                 {
+                    "name": "MinCourseRoleGrader",
+                    "type": "min-course-role-grader"
+                },
+                {
                     "name": "course-id",
                     "type": "string",
                     "description": "The ID of the course to make this request to.",
@@ -191,6 +211,10 @@
         "courses/assignments/submissions/analysis/individual": {
             "description": "Get the result of a individual analysis for the specified submissions.",
             "input": [
+                {
+                    "name": "MinServerRoleUser",
+                    "type": "min-server-role-user"
+                },
                 {
                     "name": "dry-run",
                     "type": "bool",
@@ -252,6 +276,10 @@
             "description": "Get the result of a pairwise analysis for the specified submissions.",
             "input": [
                 {
+                    "name": "MinServerRoleUser",
+                    "type": "min-server-role-user"
+                },
+                {
                     "name": "dry-run",
                     "type": "bool",
                     "description": "Don't save anything."
@@ -312,6 +340,10 @@
             "description": "Get all recent submissions and grading information for this assignment.",
             "input": [
                 {
+                    "name": "MinCourseRoleGrader",
+                    "type": "min-course-role-grader"
+                },
+                {
                     "name": "assignment-id",
                     "type": "string",
                     "description": "The ID of the assignment to make this request to.",
@@ -352,6 +384,10 @@
             "description": "Get a summary of the most recent scores for this assignment.",
             "input": [
                 {
+                    "name": "MinCourseRoleGrader",
+                    "type": "min-course-role-grader"
+                },
+                {
                     "name": "assignment-id",
                     "type": "string",
                     "description": "The ID of the assignment to make this request to.",
@@ -391,6 +427,10 @@
         "courses/assignments/submissions/fetch/user/attempt": {
             "description": "Get a submission along with all grading information.",
             "input": [
+                {
+                    "name": "MinCourseRoleStudent",
+                    "type": "min-course-role-student"
+                },
                 {
                     "name": "assignment-id",
                     "type": "string",
@@ -443,6 +483,10 @@
             "description": "Get all submission attempts made by a user along with all grading information.",
             "input": [
                 {
+                    "name": "MinCourseRoleGrader",
+                    "type": "min-course-role-grader"
+                },
+                {
                     "name": "assignment-id",
                     "type": "string",
                     "description": "The ID of the assignment to make this request to.",
@@ -486,6 +530,10 @@
             "description": "Get a summary of the submissions for this assignment.",
             "input": [
                 {
+                    "name": "MinCourseRoleStudent",
+                    "type": "min-course-role-student"
+                },
+                {
                     "name": "assignment-id",
                     "type": "string",
                     "description": "The ID of the assignment to make this request to.",
@@ -528,6 +576,10 @@
         "courses/assignments/submissions/fetch/user/peek": {
             "description": "Get a copy of the grading report for the specified submission. Does not submit a new submission.",
             "input": [
+                {
+                    "name": "MinCourseRoleStudent",
+                    "type": "min-course-role-student"
+                },
                 {
                     "name": "assignment-id",
                     "type": "string",
@@ -579,6 +631,10 @@
         "courses/assignments/submissions/proxy/regrade": {
             "description": "Proxy regrade an assignment for all target users using their most recent submission.",
             "input": [
+                {
+                    "name": "MinCourseRoleGrader",
+                    "type": "min-course-role-grader"
+                },
                 {
                     "name": "assignment-id",
                     "type": "string",
@@ -657,6 +713,10 @@
             "description": "Proxy resubmit an assignment submission to the autograder.",
             "input": [
                 {
+                    "name": "MinCourseRoleGrader",
+                    "type": "min-course-role-grader"
+                },
+                {
                     "name": "assignment-id",
                     "type": "string",
                     "description": "The ID of the assignment to make this request to.",
@@ -725,6 +785,10 @@
             "description": "Proxy submit an assignment submission to the autograder.",
             "input": [
                 {
+                    "name": "MinCourseRoleGrader",
+                    "type": "min-course-role-grader"
+                },
+                {
                     "name": "assignment-id",
                     "type": "string",
                     "description": "The ID of the assignment to make this request to.",
@@ -789,6 +853,10 @@
             "description": "Remove a specified submission. Defaults to the most recent submission.",
             "input": [
                 {
+                    "name": "MinCourseRoleGrader",
+                    "type": "min-course-role-grader"
+                },
+                {
                     "name": "assignment-id",
                     "type": "string",
                     "description": "The ID of the assignment to make this request to.",
@@ -835,6 +903,10 @@
         "courses/assignments/submissions/submit": {
             "description": "Submit an assignment submission to the autograder.",
             "input": [
+                {
+                    "name": "MinCourseRoleStudent",
+                    "type": "min-course-role-student"
+                },
                 {
                     "name": "allow-late",
                     "type": "bool"
@@ -891,6 +963,10 @@
             "description": "Perform a full scoring and upload scores to the course's LMS.",
             "input": [
                 {
+                    "name": "MinCourseRoleAdmin",
+                    "type": "min-course-role-admin"
+                },
+                {
                     "name": "course-id",
                     "type": "string",
                     "description": "The ID of the course to make this request to.",
@@ -927,6 +1003,10 @@
         "courses/stats/query": {
             "description": "Query metrics for a specific course.\nOnly the context course can be queried for, the target-course field will be ignored for this endpoint.",
             "input": [
+                {
+                    "name": "MinCourseRoleAdmin",
+                    "type": "min-course-role-admin"
+                },
                 {
                     "name": "after",
                     "type": "int64",
@@ -988,6 +1068,10 @@
             "description": "Upsert a course using a filespec.",
             "input": [
                 {
+                    "name": "MinServerRoleCourseCreator",
+                    "type": "min-server-role-course-creator"
+                },
+                {
                     "name": "dry-run",
                     "type": "bool"
                 },
@@ -1040,6 +1124,10 @@
             "description": "Upsert a course using a zip file.",
             "input": [
                 {
+                    "name": "MinServerRoleCourseCreator",
+                    "type": "min-server-role-course-creator"
+                },
+                {
                     "name": "dry-run",
                     "type": "bool"
                 },
@@ -1087,6 +1175,10 @@
             "description": "Drop a user from the course.",
             "input": [
                 {
+                    "name": "MinCourseRoleAdmin",
+                    "type": "min-course-role-admin"
+                },
+                {
                     "name": "course-id",
                     "type": "string",
                     "description": "The ID of the course to make this request to.",
@@ -1120,6 +1212,10 @@
         "courses/users/enroll": {
             "description": "Enroll one or more users to the course.",
             "input": [
+                {
+                    "name": "MinCourseRoleAdmin",
+                    "type": "min-course-role-admin"
+                },
                 {
                     "name": "course-id",
                     "type": "string",
@@ -1173,6 +1269,10 @@
             "description": "Get the information for a course user.",
             "input": [
                 {
+                    "name": "MinCourseRoleOther",
+                    "type": "min-course-role-other"
+                },
+                {
                     "name": "course-id",
                     "type": "string",
                     "description": "The ID of the course to make this request to.",
@@ -1210,6 +1310,10 @@
             "description": "List the users in the course.",
             "input": [
                 {
+                    "name": "MinCourseRoleGrader",
+                    "type": "min-course-role-grader"
+                },
+                {
                     "name": "course-id",
                     "type": "string",
                     "description": "The ID of the course to make this request to.",
@@ -1242,6 +1346,10 @@
         "lms/upload/scores": {
             "description": "Upload scores from a tab-separated file to the course's LMS.\nThe file should not have headers, and should have two columns: email and score.",
             "input": [
+                {
+                    "name": "MinCourseRoleGrader",
+                    "type": "min-course-role-grader"
+                },
                 {
                     "name": "assignment-lms-id",
                     "type": "string",
@@ -1294,6 +1402,10 @@
             "description": "Get information for an LMS user.",
             "input": [
                 {
+                    "name": "MinCourseRoleGrader",
+                    "type": "min-course-role-grader"
+                },
+                {
                     "name": "course-id",
                     "type": "string",
                     "description": "The ID of the course to make this request to.",
@@ -1335,6 +1447,10 @@
         "logs/query": {
             "description": "Query log entries from the autograder server.",
             "input": [
+                {
+                    "name": "MinServerRoleUser",
+                    "type": "min-server-role-user"
+                },
                 {
                     "name": "after",
                     "type": "string"
@@ -1420,6 +1536,10 @@
             "description": "Query stats for the server.",
             "input": [
                 {
+                    "name": "MinServerRoleAdmin",
+                    "type": "min-server-role-admin"
+                },
+                {
                     "name": "after",
                     "type": "int64",
                     "description": "Only return data from after this time.\nA value of zero is treated normally here (as UNIX epoch)."
@@ -1474,6 +1594,10 @@
             "description": "Get stack traces for all the currently running routines (threads) on the server.",
             "input": [
                 {
+                    "name": "MinServerRoleAdmin",
+                    "type": "min-server-role-admin"
+                },
+                {
                     "name": "user-email",
                     "type": "string",
                     "description": "The email of the user making this request.",
@@ -1524,6 +1648,10 @@
             "description": "Get the information for a server user.",
             "input": [
                 {
+                    "name": "MinServerRoleUser",
+                    "type": "min-server-role-user"
+                },
+                {
                     "name": "target-email",
                     "type": "core.TargetServerUserSelfOrAdmin"
                 },
@@ -1558,6 +1686,10 @@
         "users/list": {
             "description": "List the users on the server.",
             "input": [
+                {
+                    "name": "MinServerRoleAdmin",
+                    "type": "min-server-role-admin"
+                },
                 {
                     "name": "target-users",
                     "type": "[]model.ServerUserReference"
@@ -1628,6 +1760,10 @@
         "users/remove": {
             "description": "Remove a user from the server.",
             "input": [
+                {
+                    "name": "MinServerRoleAdmin",
+                    "type": "min-server-role-admin"
+                },
                 {
                     "name": "target-email",
                     "type": "core.TargetServerUser",
@@ -1715,6 +1851,10 @@
         "users/upsert": {
             "description": "Upsert one or more users to the server (update if exists, insert otherwise).",
             "input": [
+                {
+                    "name": "MinServerRoleAdmin",
+                    "type": "min-server-role-admin"
+                },
                 {
                     "name": "dry-run",
                     "type": "bool",
@@ -2116,6 +2256,34 @@
                     "type": "string"
                 }
             ]
+        },
+        "min-course-role-admin": {
+            "category": "role",
+            "description": "The requesting user must have a minimum course role of admin to complete this operation."
+        },
+        "min-course-role-grader": {
+            "category": "role",
+            "description": "The requesting user must have a minimum course role of grader to complete this operation."
+        },
+        "min-course-role-other": {
+            "category": "role",
+            "description": "The requesting user must have a minimum course role of other to complete this operation."
+        },
+        "min-course-role-student": {
+            "category": "role",
+            "description": "The requesting user must have a minimum course role of student to complete this operation."
+        },
+        "min-server-role-admin": {
+            "category": "role",
+            "description": "The requesting user must have a minimum server role of admin to complete this operation."
+        },
+        "min-server-role-course-creator": {
+            "category": "role",
+            "description": "The requesting user must have a minimum server role of course creator to complete this operation."
+        },
+        "min-server-role-user": {
+            "category": "role",
+            "description": "The requesting user must have a minimum server role of user to complete this operation."
         },
         "model.AnalysisFileInfo": {
             "category": "struct",


### PR DESCRIPTION
This PR adds support for overriding the automatic type description that is generated when describing all API endpoints.

One limitation of this PR is that types that are ignored by JSON (using the `-` JSON tag) cannot have their type description overriden. In the future, we will want to add support for this situation so API endpoints can display that they accept POST files.

Currently, the only types to include a type overrides are `Min*Role*` types.