### PR TITLE
Move submission file copy into Docker container for isolation

### DIFF
--- a/internal/docker/fileprep.go
+++ b/internal/docker/fileprep.go
@@ -1,0 +1,62 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/edulinq/autograder/internal/config"
+	"github.com/edulinq/autograder/internal/util"
+)
+
+const FILE_PREP_IMAGE = "alpine:3.19"
+const FILE_PREP_TIMEOUT_SECS = 60
+
+// Copy directory contents inside a Docker container for isolation.
+// Source is mounted read-only, dest is mounted read-write.
+// Equivalent to: cp -r /source/* /dest/
+// Falls back to host-based copy when Docker is disabled.
+func CopyDirContentsInContainer(source string, dest string) error {
+	if config.DOCKER_DISABLE.Get() {
+		return util.CopyDirContents(source, dest)
+	}
+
+	err := EnsureImage(FILE_PREP_IMAGE)
+	if err != nil {
+		return fmt.Errorf("Failed to ensure file prep image '%s': '%w'", FILE_PREP_IMAGE, err)
+	}
+
+	mounts := []MountInfo{
+		{
+			Source:   util.ShouldAbs(source),
+			Target:   "/source",
+			ReadOnly: true,
+		},
+		{
+			Source:   util.ShouldAbs(dest),
+			Target:   "/dest",
+			ReadOnly: false,
+		},
+	}
+
+	cmd := []string{"sh", "-c", "cp -r /source/. /dest/"}
+
+	stdout, stderr, timeout, _, err := RunContainer(
+		context.Background(),
+		nil,
+		FILE_PREP_IMAGE,
+		mounts,
+		cmd,
+		"fileprep",
+		FILE_PREP_TIMEOUT_SECS,
+	)
+
+	if err != nil {
+		return fmt.Errorf("File prep container failed: %w (stdout: %s, stderr: %s)", err, stdout, stderr)
+	}
+
+	if timeout {
+		return fmt.Errorf("File prep container timed out (stdout: %s, stderr: %s)", stdout, stderr)
+	}
+
+	return nil
+}

--- a/internal/grader/docker.go
+++ b/internal/grader/docker.go
@@ -31,8 +31,8 @@ func runDockerGrader(ctx context.Context, assignment *model.Assignment, submissi
 		log.Debug("Leaving behind temp grading dir.", assignment, log.NewAttr("path", tempDir))
 	}
 
-	// Copy over submission files to the temp input dir.
-	err = util.CopyDirentFull(submissionPath, inputDir, true)
+	// Copy over submission files to the temp input dir inside a container for isolation.
+	err = docker.CopyDirContentsInContainer(submissionPath, inputDir)
 	if err != nil {
 		return nil, nil, "", "", "", fmt.Errorf("Failed to copy over submission/input contents: '%w'.", err)
 	}


### PR DESCRIPTION
## Summary

Move the submission file copy step from the host into a dedicated Docker container.

## Change

The submission directory copy now runs inside a small, dedicated Docker container instead of directly on the host. The source directory is mounted read-only and the destination is mounted read-write, establishing a clear isolation boundary for file preparation.

## Scope

This change is intentionally minimal:
- No resource limits are introduced
- No behavioral changes beyond where the copy runs
- Focused on a single file-prep step only
