### PR TITLE
Added proxy user and time to submission comments

### DIFF
--- a/internal/model/grading.go
+++ b/internal/model/grading.go
@@ -66,6 +66,8 @@ func (this *GradingResult) GetCombinedOutput() string {
 
 func (this GradingInfo) ToScoringInfo() *ScoringInfo {
 	return &ScoringInfo{
+		ProxyUser: 				 this.ProxyUser,
+		ProxyTime: 				 this.ProxyStartTime,
 		ID:                      this.ID,
 		SubmissionTime:          this.GradingStartTime,
 		RawScore:                this.Score,

--- a/internal/model/grading.go
+++ b/internal/model/grading.go
@@ -66,8 +66,8 @@ func (this *GradingResult) GetCombinedOutput() string {
 
 func (this GradingInfo) ToScoringInfo() *ScoringInfo {
 	return &ScoringInfo{
-		ProxyUser: 				 this.ProxyUser,
-		ProxyTime: 				 this.ProxyStartTime,
+		ProxyUser:               this.ProxyUser,
+		ProxyTime:               this.ProxyStartTime,
 		ID:                      this.ID,
 		SubmissionTime:          this.GradingStartTime,
 		RawScore:                this.Score,

--- a/internal/model/scoring.go
+++ b/internal/model/scoring.go
@@ -7,15 +7,17 @@ import (
 const SCORING_INFO_STRUCT_VERSION = "1.0.0"
 
 type ScoringInfo struct {
-	ID             string              `json:"id"`
-	SubmissionTime timestamp.Timestamp `json:"submission-time"`
-	UploadTime     timestamp.Timestamp `json:"upload-time"`
-	RawScore       float64             `json:"raw-score"`
-	Score          float64             `json:"score"`
-	Lock           bool                `json:"lock"`
-	LateDayUsage   int                 `json:"late-date-usage"`
-	NumDaysLate    int                 `json:"num-days-late"`
-	Reject         bool                `json:"reject"`
+	ProxyUser	   string	            `json:"proxy-user,omitempty"`
+	ProxyTime      *timestamp.Timestamp `json:"proxy-time,omitempty"`
+	ID             string               `json:"id"`
+	SubmissionTime timestamp.Timestamp  `json:"submission-time"`
+	UploadTime     timestamp.Timestamp  `json:"upload-time"`
+	RawScore       float64              `json:"raw-score"`
+	Score          float64              `json:"score"`
+	Lock           bool                 `json:"lock"`
+	LateDayUsage   int                  `json:"late-date-usage"`
+	NumDaysLate    int                  `json:"num-days-late"`
+	Reject         bool                 `json:"reject"`
 
 	// A distinct key so we can recognize this as an autograder object.
 	AutograderStructVersion string `json:"__autograder__version__"`
@@ -41,7 +43,17 @@ func (this *ScoringInfo) Equal(other *ScoringInfo) bool {
 		return false
 	}
 
-	return (this.ID == other.ID &&
+	if this.ProxyTime != other.ProxyTime {
+		if (this.ProxyTime == nil) || (other.ProxyTime == nil) {
+			return false
+		}
+		if *this.ProxyTime != *other.ProxyTime {
+			return false
+		}
+	}
+
+	return (this.ProxyUser == other.ProxyUser &&
+		this.ID == other.ID &&
 		this.SubmissionTime == other.SubmissionTime &&
 		this.RawScore == other.RawScore &&
 		this.Score == other.Score &&

--- a/internal/model/scoring.go
+++ b/internal/model/scoring.go
@@ -7,7 +7,7 @@ import (
 const SCORING_INFO_STRUCT_VERSION = "1.0.0"
 
 type ScoringInfo struct {
-	ProxyUser	   string	            `json:"proxy-user,omitempty"`
+	ProxyUser      string               `json:"proxy-user,omitempty"`
 	ProxyTime      *timestamp.Timestamp `json:"proxy-time,omitempty"`
 	ID             string               `json:"id"`
 	SubmissionTime timestamp.Timestamp  `json:"submission-time"`

--- a/internal/model/scoring.go
+++ b/internal/model/scoring.go
@@ -47,6 +47,7 @@ func (this *ScoringInfo) Equal(other *ScoringInfo) bool {
 		if (this.ProxyTime == nil) || (other.ProxyTime == nil) {
 			return false
 		}
+
 		if *this.ProxyTime != *other.ProxyTime {
 			return false
 		}

--- a/internal/model/scoring_test.go
+++ b/internal/model/scoring_test.go
@@ -15,7 +15,8 @@ func TestScoringInfoStruct(test *testing.T) {
 	testCases := []*ScoringInfo{
 		nil,
 		&ScoringInfo{},
-		&ScoringInfo{"foo", timestamp.Zero(), timestamp.Zero(), 1.0, 2.0, false, 1, 2, true, SCORING_INFO_STRUCT_VERSION, "foo", "bar"},
+		&ScoringInfo{"", nil, "foo", timestamp.Zero(), timestamp.Zero(), 1.0, 2.0, false, 1, 2, true, SCORING_INFO_STRUCT_VERSION, "foo", "bar"},
+		&ScoringInfo{ProxyUser: "grader@test.edulinq.org", ProxyTime: timestamp.ZeroPointer()},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/model/scoring_test.go
+++ b/internal/model/scoring_test.go
@@ -15,8 +15,7 @@ func TestScoringInfoStruct(test *testing.T) {
 	testCases := []*ScoringInfo{
 		nil,
 		&ScoringInfo{},
-		&ScoringInfo{"", nil, "foo", timestamp.Zero(), timestamp.Zero(), 1.0, 2.0, false, 1, 2, true, SCORING_INFO_STRUCT_VERSION, "foo", "bar"},
-		&ScoringInfo{ProxyUser: "grader@test.edulinq.org", ProxyTime: timestamp.ZeroPointer()},
+		&ScoringInfo{"grader@test.edulinq.org", timestamp.ZeroPointer(), "foo", timestamp.Zero(), timestamp.Zero(), 1.0, 2.0, false, 1, 2, true, SCORING_INFO_STRUCT_VERSION, "foo", "bar"},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/scoring/course_test.go
+++ b/internal/scoring/course_test.go
@@ -55,15 +55,13 @@ func TestCourseScoringProxy(test *testing.T) {
 	course.Assignments["hw0"].LMSID = "001"
 	assignment := course.Assignments["hw0"]
 
-	proxyTime := timestamp.FromMSecs(1697500000000)
-
 	submission, err := db.GetSubmissionContents(assignment, "course-student@test.edulinq.org", "1697406272")
 	if err != nil {
 		test.Fatalf("Failed to load submission: '%v'.", err)
 	}
 
 	submission.Info.ProxyUser = "course-grader@test.edulinq.org"
-	submission.Info.ProxyStartTime = &proxyTime
+	submission.Info.ProxyStartTime = &expectedProxyTime
 
 	err = db.SaveSubmission(assignment, submission)
 	if err != nil {

--- a/internal/scoring/course_test.go
+++ b/internal/scoring/course_test.go
@@ -19,7 +19,7 @@ func TestCourseScoringBase(test *testing.T) {
 	// Set the assignment's LMS ID.
 	course.Assignments["hw0"].LMSID = "001"
 
-	runAndtestResult(test, course)
+	runAndtestResult(test, course, expected)
 }
 
 // Make sure a student has no submissions.
@@ -44,10 +44,36 @@ func TestCourseScoringEmptyStudent(test *testing.T) {
 		test.Fatalf("Failed to save user: '%v'.", err)
 	}
 
-	runAndtestResult(test, course)
+	runAndtestResult(test, course, expected)
 }
 
-func runAndtestResult(test *testing.T, course *model.Course) {
+func TestCourseScoringProxy(test *testing.T) {
+	db.ResetForTesting()
+	defer db.ResetForTesting()
+
+	course := db.MustGetTestCourse()
+	course.Assignments["hw0"].LMSID = "001"
+	assignment := course.Assignments["hw0"]
+
+	proxyTime := timestamp.FromMSecs(1697500000000)
+
+	submission, err := db.GetSubmissionContents(assignment, "course-student@test.edulinq.org", "1697406272")
+	if err != nil {
+		test.Fatalf("Failed to load submission: '%v'.", err)
+	}
+
+	submission.Info.ProxyUser = "course-grader@test.edulinq.org"
+	submission.Info.ProxyStartTime = &proxyTime
+
+	err = db.SaveSubmission(assignment, submission)
+	if err != nil {
+		test.Fatalf("Failed to re-save proxy submission: '%v'.", err)
+	}
+
+	runAndtestResult(test, course, expectedProxy)
+}
+
+func runAndtestResult(test *testing.T, course *model.Course, expected map[string]map[string]*model.ScoringInfo) {
 	actual, err := FullCourseScoringAndUpload(course, true)
 	if err != nil {
 		test.Fatalf("Course score upload (dryrun) failed: '%v'.", err)
@@ -87,6 +113,23 @@ var expected map[string]map[string]*model.ScoringInfo = map[string]map[string]*m
 			LateDayUsage:            0,
 			NumDaysLate:             0,
 			Reject:                  false,
+			AutograderStructVersion: model.SCORING_INFO_STRUCT_VERSION,
+		},
+	},
+}
+
+var expectedProxyTime timestamp.Timestamp = timestamp.FromMSecs(1697500000000)
+
+var expectedProxy map[string]map[string]*model.ScoringInfo = map[string]map[string]*model.ScoringInfo{
+	"hw0": map[string]*model.ScoringInfo{
+		"course-student@test.edulinq.org": &model.ScoringInfo{
+			ProxyUser:               "course-grader@test.edulinq.org",
+			ProxyTime:               &expectedProxyTime,
+			ID:                      "course101::hw0::course-student@test.edulinq.org::1697406272",
+			SubmissionTime:          timestamp.FromMSecs(1697406273000),
+			UploadTime:              timestamp.Zero(),
+			RawScore:                2,
+			Score:                   2,
 			AutograderStructVersion: model.SCORING_INFO_STRUCT_VERSION,
 		},
 	},

--- a/internal/scoring/course_test.go
+++ b/internal/scoring/course_test.go
@@ -67,7 +67,7 @@ func TestCourseScoringProxy(test *testing.T) {
 
 	err = db.SaveSubmission(assignment, submission)
 	if err != nil {
-		test.Fatalf("Failed to re-save proxy submission: '%v'.", err)
+		test.Fatalf("Failed to save proxy information: '%v'.", err)
 	}
 
 	runAndtestResult(test, course, expectedProxy)
@@ -130,6 +130,10 @@ var expectedProxy map[string]map[string]*model.ScoringInfo = map[string]map[stri
 			UploadTime:              timestamp.Zero(),
 			RawScore:                2,
 			Score:                   2,
+			Lock:                    false,
+			LateDayUsage:            0,
+			NumDaysLate:             0,
+			Reject:                  false,
 			AutograderStructVersion: model.SCORING_INFO_STRUCT_VERSION,
 		},
 	},


### PR DESCRIPTION
Added the proxy user and proxy time fields to the ScoringInfo type to address issue #28. The scoring and upload process can now take the proxy user and time from submissions and include them in the uploaded comment. Added a test for the uploading of these fields in scoring/course_test.